### PR TITLE
Type fully_diluted_valuation and  max_supply with possible number

### DIFF
--- a/src/Interface.ts
+++ b/src/Interface.ts
@@ -83,7 +83,7 @@ export interface CoinMarket extends BasicCoin {
   current_price?: number;
   market_cap?: number;
   market_cap_rank?: number;
-  fully_diluted_valuation?: null;
+  fully_diluted_valuation?: null | number;
   total_volume?: number;
   high_24h?: number;
   low_24h?: number;
@@ -93,7 +93,7 @@ export interface CoinMarket extends BasicCoin {
   market_cap_change_percentage_24h?: number;
   circulating_supply?: number;
   total_supply?: number;
-  max_supply?: null;
+  max_supply?: null | number;
   ath?: number;
   ath_change_percentage?: number;
   ath_date?: Date;


### PR DESCRIPTION
`/api/v3/coins/markets` returns type CoinMarket but fully_diluted_valuation and max_supply are declared as undefined or null only. 

In fact, it returns numbers but the type `number` is missing.